### PR TITLE
Stream subprovider

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,16 @@
 Utility for creating an Ethereum web3 provider that forwards payloads through a stream.
 Only works for **async** payloads.
 
+### For connecting to a remote eth rpc handler
 
-For connecting to a remote eth rpc handler
 ```js
 const StreamProvider = require('web3-stream-provider')
 
 var streamProvider = new StreamProvider()
 var web3 = new Web3(streamProvider)
 
-streamProvider.pipe(remoteRpcHandler).pipe(streamProvider)
+streamProvider.stream.pipe(remoteRpcHandler).pipe(streamProvider.stream)
 ```
-
 
 For handling incoming rpc payloads
 ```js
@@ -25,3 +24,18 @@ function logger(err, request, response){
   console.log(arguments)
 }
 ```
+
+## Pre-Version-3.0.0 Stream API
+
+The StreamProvider used to be a stream itself, so previously you would use its stream directly, like this:
+
+For connecting to a remote eth rpc handler
+```js
+const StreamProvider = require('web3-stream-provider')
+
+var streamProvider = new StreamProvider()
+var web3 = new Web3(streamProvider)
+
+streamProvider.pipe(remoteRpcHandler).pipe(streamProvider)
+```
+

--- a/index.js
+++ b/index.js
@@ -2,18 +2,16 @@ const ProviderEngine = require('web3-provider-engine')
 const StreamSubprovider = require('./stream-subprovider')
 const inherits = require('inherits')
 
-module.exports = StreamProvider
+inherits(StreamProvider, ProviderEngine)
 
+function StreamProvider () {
+  ProviderEngine.call(this)
 
-function StreamProvider(){
-  const engine = new ProviderEngine()
-
-  const streamSubprovider = new StreamSubprovider()
-  engine.addProvider(streamSubprovider)
-
-  // start polling
-  engine.start()
-
-  return engine
+  const streamSubprovider = this.stream = new StreamSubprovider()
+  this.addProvider(streamSubprovider)
+  this.start()
 }
+
+
+module.exports = StreamProvider
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const Duplex = require('readable-stream').Duplex
-const inherits = require('util').inherits
+const ProviderEngine = require('web3-provider-engine')
+const StreamSubprovider = require('./stream-subprovider')
 
 module.exports = StreamProvider
 
@@ -7,81 +7,14 @@ module.exports = StreamProvider
 inherits(StreamProvider, Duplex)
 
 function StreamProvider(){
-  Duplex.call(this, {
-    objectMode: true,
-  })
+  const engine = new ProviderEngine()
 
-  this._payloads = {}
+  const streamSubprovider = new StreamSubprovider()
+  engine.addProvider(streamSubprovider)
+
+  // start polling
+  engine.start()
+
+  return engine
 }
 
-// public
-
-StreamProvider.prototype.send = function(payload){
-  throw new Error('StreamProvider - does not support synchronous RPC calls. called: "'+payload.method+'"')
-}
-
-StreamProvider.prototype.sendAsync = function(payload, callback){
-  // console.log('StreamProvider - sending payload', payload)
-  var id = payload.id
-  // handle batch requests
-  if (Array.isArray(payload)) {
-    // short circuit for empty batch requests
-    if (payload.length === 0){
-      return callback(null, [])
-    }
-    id = generateBatchId(payload)
-  }
-  // store request details
-  this._payloads[id] = [payload, callback]
-  // console.log('payload for plugin:', payload)
-  this.push(payload)
-}
-
-StreamProvider.prototype.isConnected = function(){
-  return true
-}
-
-// private
-
-StreamProvider.prototype._onResponse = function(response){
-  // console.log('StreamProvider - got response', payload)
-  var id = response.id
-  // handle batch requests
-  if (Array.isArray(response)) {
-    id = generateBatchId(response)
-  }
-  var data = this._payloads[id]
-  if (!data) throw new Error('StreamProvider - Unknown response id')
-  delete this._payloads[id]
-  var payload = data[0]
-  var callback = data[1]
-
-  // logging
-  // var res = Array.isArray(response) ? response : [response]
-  // ;(Array.isArray(payload) ? payload : [payload]).forEach(function(payload, index){
-  //   console.log('plugin response:', payload.id, payload.method, payload.params, '->', res[index].result)
-  // })
-
-  // run callback on empty stack,
-  // prevent internal stream-handler from catching errors
-  setTimeout(function(){
-    callback(null, response)
-  })
-}
-
-// stream plumbing
-
-StreamProvider.prototype._read = noop
-
-StreamProvider.prototype._write = function(msg, encoding, cb){
-  this._onResponse(msg)
-  cb()
-}
-
-// util
-
-function generateBatchId(batchPayload){
-  return 'batch:'+batchPayload.map(function(payload){ return payload.id }).join(',')
-}
-
-function noop(){}

--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 const ProviderEngine = require('web3-provider-engine')
 const StreamSubprovider = require('./stream-subprovider')
+const inherits = require('inherits')
 
 module.exports = StreamProvider
 
-
-inherits(StreamProvider, Duplex)
 
 function StreamProvider(){
   const engine = new ProviderEngine()

--- a/index.js
+++ b/index.js
@@ -4,14 +4,13 @@ const inherits = require('inherits')
 
 inherits(StreamProvider, ProviderEngine)
 
-function StreamProvider () {
-  ProviderEngine.call(this)
+function StreamProvider (opts) {
+  ProviderEngine.call(this, opts)
 
   const streamSubprovider = this.stream = new StreamSubprovider()
   this.addProvider(streamSubprovider)
   this.start()
 }
-
 
 module.exports = StreamProvider
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-stream-provider",
-  "version": "2.0.8",
+  "version": "3.0.0",
   "description": "Utility for creating an Ethereum web3 provider that forwards payloads through a stream.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "author": "kumavis",
   "license": "ISC",
   "dependencies": {
-    "readable-stream": "^2.0.5"
+    "readable-stream": "^2.0.5",
+    "web3-provider-engine": "^12.0.6"
   },
   "devDependencies": {},
   "repository": {

--- a/stream-subprovider.js
+++ b/stream-subprovider.js
@@ -1,0 +1,75 @@
+const Duplex = require('readable-stream').Duplex
+const inherits = require('util').inherits
+const Subprovider = require('web3-provider-engine/subproviders/subprovider.js')
+
+module.exports = StreamSubprovider
+
+
+inherits(StreamSubprovider, Duplex)
+
+function StreamSubprovider(){
+  Duplex.call(this, {
+    objectMode: true,
+  })
+
+  this._payloads = {}
+}
+
+StreamSubprovider.prototype.handleRequest = function(payload, next, end){
+  var id = payload.id
+  // handle batch requests
+  if (Array.isArray(payload)) {
+    // short circuit for empty batch requests
+    if (payload.length === 0){
+      return callback(null, [])
+    }
+    id = generateBatchId(payload)
+  }
+  // store request details
+  this._payloads[id] = [payload, end]
+  // console.log('payload for plugin:', payload)
+  this.push(payload)
+}
+
+// private
+
+StreamSubprovider.prototype._onResponse = function(response){
+  // console.log('StreamSubprovider - got response', payload)
+  var id = response.id
+  // handle batch requests
+  if (Array.isArray(response)) {
+    id = generateBatchId(response)
+  }
+  var data = this._payloads[id]
+  if (!data) throw new Error('StreamSubprovider - Unknown response id')
+  delete this._payloads[id]
+  var payload = data[0]
+  var callback = data[1]
+
+  // run callback on empty stack,
+  // prevent internal stream-handler from catching errors
+  setTimeout(function(){
+    callback(null, response)
+  })
+}
+
+// stream plumbing
+
+StreamSubprovider.prototype._read = noop
+
+StreamSubprovider.prototype._write = function(msg, encoding, cb){
+  this._onResponse(msg)
+  cb()
+}
+
+// util
+
+function generateBatchId(batchPayload){
+  return 'batch:'+batchPayload.map(function(payload){ return payload.id }).join(',')
+}
+
+function noop(){}
+
+
+module.exports = StreamSubprovider
+

--- a/stream-subprovider.js
+++ b/stream-subprovider.js
@@ -28,7 +28,19 @@ StreamSubprovider.prototype.handleRequest = function(payload, next, end){
   }
   // store request details
   this._payloads[id] = [payload, end]
-  this.push(payload)
+  this.write(payload)
+}
+
+StreamSubprovider.prototype.setEngine = noop
+
+// stream plumbing
+
+StreamSubprovider.prototype._read = noop
+
+StreamSubprovider.prototype._write = function(msg, encoding, cb){
+  console.log('stream got write', msg)
+  this._onResponse(msg)
+  cb()
 }
 
 // private
@@ -43,7 +55,6 @@ StreamSubprovider.prototype._onResponse = function(response){
   var data = this._payloads[id]
   if (!data) throw new Error('StreamSubprovider - Unknown response id')
   delete this._payloads[id]
-  var payload = data[0]
   var callback = data[1]
 
   // run callback on empty stack,
@@ -53,17 +64,6 @@ StreamSubprovider.prototype._onResponse = function(response){
   })
 }
 
-StreamSubprovider.prototype.setEngine = noop
-
-// stream plumbing
-
-StreamSubprovider.prototype._read = noop
-
-StreamSubprovider.prototype._write = function(msg, encoding, cb){
-  console.log('stream got write', msg)
-  this._onResponse(msg)
-  cb()
-}
 
 // util
 

--- a/stream-subprovider.js
+++ b/stream-subprovider.js
@@ -16,7 +16,6 @@ function StreamSubprovider(){
 }
 
 StreamSubprovider.prototype.handleRequest = function(payload, next, end){
-  console.log('stream subprovider handleRequest', payload)
   var id = payload.id
   // handle batch requests
   if (Array.isArray(payload)) {
@@ -45,7 +44,6 @@ StreamSubprovider.prototype._write = function(msg, encoding, cb){
 // private
 
 StreamSubprovider.prototype._onResponse = function(response){
-  console.log('StreamSubprovider _onResponse', response)
   var id = response.id
   // handle batch requests
   if (Array.isArray(response)) {

--- a/stream-subprovider.js
+++ b/stream-subprovider.js
@@ -16,6 +16,7 @@ function StreamSubprovider(){
 }
 
 StreamSubprovider.prototype.handleRequest = function(payload, next, end){
+  console.log('stream subprovider handling', payload)
   var id = payload.id
   // handle batch requests
   if (Array.isArray(payload)) {
@@ -27,14 +28,13 @@ StreamSubprovider.prototype.handleRequest = function(payload, next, end){
   }
   // store request details
   this._payloads[id] = [payload, end]
-  // console.log('payload for plugin:', payload)
   this.push(payload)
 }
 
 // private
 
 StreamSubprovider.prototype._onResponse = function(response){
-  // console.log('StreamSubprovider - got response', payload)
+  console.log('StreamSubprovider - got response', response)
   var id = response.id
   // handle batch requests
   if (Array.isArray(response)) {
@@ -60,6 +60,7 @@ StreamSubprovider.prototype.setEngine = noop
 StreamSubprovider.prototype._read = noop
 
 StreamSubprovider.prototype._write = function(msg, encoding, cb){
+  console.log('stream got write', msg)
   this._onResponse(msg)
   cb()
 }

--- a/stream-subprovider.js
+++ b/stream-subprovider.js
@@ -53,6 +53,8 @@ StreamSubprovider.prototype._onResponse = function(response){
   })
 }
 
+StreamSubprovider.prototype.setEngine = noop
+
 // stream plumbing
 
 StreamSubprovider.prototype._read = noop

--- a/stream-subprovider.js
+++ b/stream-subprovider.js
@@ -16,7 +16,7 @@ function StreamSubprovider(){
 }
 
 StreamSubprovider.prototype.handleRequest = function(payload, next, end){
-  console.log('stream subprovider handling', payload)
+  console.log('stream subprovider handleRequest', payload)
   var id = payload.id
   // handle batch requests
   if (Array.isArray(payload)) {
@@ -38,7 +38,6 @@ StreamSubprovider.prototype.setEngine = noop
 StreamSubprovider.prototype._read = noop
 
 StreamSubprovider.prototype._write = function(msg, encoding, cb){
-  console.log('stream got write', msg)
   this._onResponse(msg)
   cb()
 }
@@ -46,7 +45,7 @@ StreamSubprovider.prototype._write = function(msg, encoding, cb){
 // private
 
 StreamSubprovider.prototype._onResponse = function(response){
-  console.log('StreamSubprovider - got response', response)
+  console.log('StreamSubprovider _onResponse', response)
   var id = response.id
   // handle batch requests
   if (Array.isArray(response)) {

--- a/stream-subprovider.js
+++ b/stream-subprovider.js
@@ -28,7 +28,7 @@ StreamSubprovider.prototype.handleRequest = function(payload, next, end){
   }
   // store request details
   this._payloads[id] = [payload, end]
-  this.write(payload)
+  this.push(payload)
 }
 
 StreamSubprovider.prototype.setEngine = noop

--- a/stream-subprovider.js
+++ b/stream-subprovider.js
@@ -59,7 +59,7 @@ StreamSubprovider.prototype._onResponse = function(response){
   // run callback on empty stack,
   // prevent internal stream-handler from catching errors
   setTimeout(function(){
-    callback(null, response)
+    callback(null, response.result)
   })
 }
 


### PR DESCRIPTION
Now is itself a `ProviderEngine` instance that imports its own local `StreamSubprovider`.

To do this easily, the main provider is no longer a stream, its subprovider is, so accessing it is only possible via the `streamProvider.stream` property.

The README is updated to reflect this API change.

I have [a branch of MetaMask](https://github.com/MetaMask/metamask-plugin/blob/i1458-StreamingSubprovider/app/scripts/lib/inpage-provider.js) that is prepared to consume this new version.