### PR TITLE
feat: support readable-stream v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "kumavis",
   "license": "ISC",
   "dependencies": {
-    "readable-stream": "^3.6.2",
+    "readable-stream": "^3.6.2 || ^4.5.2",
     "uuid": "^9.0.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
Changes dependency range of `readable-stream` from `^3.6.2` to `^3.6.2 || ^4.5.2` to allow using with either streams implementation.